### PR TITLE
[BUGFIX] Remove icon, label, and allowsBackup attributes from AndroidManifest

### DIFF
--- a/tourguide/src/main/AndroidManifest.xml
+++ b/tourguide/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tourguide.tourguide">
+<manifest package="tourguide.tourguide">
 
-    <application
-        android:allowBackup="true"
-        android:icon="@drawable/ic_launcher1"
-        android:label="@string/app_name">
-
+    <application>
     </application>
 
 </manifest>


### PR DESCRIPTION
This is a better fix for one of the issues mentioned in #3 . The library should not be setting these attributes, the application using the library should. Most applications will fail to build with these attributes in the library's manifest because the library's values will conflict with the app's values and the manifest merge will fail. The demo app builds because the values are the same in the library and the demo application.
