### PR TITLE
[REFACTOR] Avoid deprication of Display.getWidth()/getHeight().

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -116,8 +116,8 @@ public class FrameLayoutWithHole extends FrameLayout {
         mTextPaint.setTextAlign(Paint.Align.LEFT);
 
         Point size = new Point();
-        size.x = mActivity.getWindowManager().getDefaultDisplay().getWidth();
-        size.y = mActivity.getWindowManager().getDefaultDisplay().getHeight();
+        size.x = mActivity.getResources().getDisplayMetrics().widthPixels;
+        size.y = mActivity.getResources().getDisplayMetrics().heightPixels;
 
         mEraserBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
         mEraserCanvas = new Canvas(mEraserBitmap);
@@ -294,8 +294,7 @@ public class FrameLayoutWithHole extends FrameLayout {
      * @return screen width in pixel
      */
     public int getScreenWidth(Activity activity){
-        Display display = activity.getWindowManager().getDefaultDisplay();
-        return display.getWidth();
+        return activity.getResources().getDisplayMetrics().widthPixels;
     }
 
     /**
@@ -306,7 +305,6 @@ public class FrameLayoutWithHole extends FrameLayout {
      * @return screen width in pixel
      */
     public int getScreenHeight(Activity activity){
-        Display display = activity.getWindowManager().getDefaultDisplay();
-        return display.getHeight();
+        return activity.getResources().getDisplayMetrics().heightPixels;
     }
 }

--- a/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
@@ -534,11 +534,7 @@ public class TourGuide {
     }
     private int getScreenWidth(){
         if (mActivity!=null) {
-            Display display = mActivity.getWindowManager().getDefaultDisplay();
-            /* getSize() is only available on API 13+ */
-//            Point size = new Point();
-//            display.getSize(size);
-            return display.getWidth();
+            return mActivity.getResources().getDisplayMetrics().widthPixels;
         } else {
             return 0;
         }


### PR DESCRIPTION
Hi, Display.getWidth()/getHeight() are depricated.

So, I tried replacing that for DisplayMetrics.widthPixels/heightPixels.

Thank you for reading.
