### PR TITLE
DisplayMetrics does not return actual screen size. #56

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -2,6 +2,7 @@ package tourguide.tourguide;
 
 import android.animation.AnimatorSet;
 import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -9,6 +10,7 @@ import android.graphics.Paint;
 import android.graphics.Point;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.os.Build;
 import android.support.v4.view.MotionEventCompat;
 import android.text.TextPaint;
 import android.util.AttributeSet;
@@ -17,8 +19,11 @@ import android.view.Display;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.widget.FrameLayout;
+
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
 /**
@@ -115,9 +120,11 @@ public class FrameLayoutWithHole extends FrameLayout {
         mTextPaint.setFlags(Paint.ANTI_ALIAS_FLAG);
         mTextPaint.setTextAlign(Paint.Align.LEFT);
 
-        Point size = new Point();
+        Point size = getRealScreenSize(mActivity);
+
+        /*Point size = new Point();
         size.x = mActivity.getResources().getDisplayMetrics().widthPixels;
-        size.y = mActivity.getResources().getDisplayMetrics().heightPixels;
+        size.y = mActivity.getResources().getDisplayMetrics().heightPixels;*/
 
         mEraserBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
         mEraserCanvas = new Canvas(mEraserBitmap);
@@ -136,6 +143,23 @@ public class FrameLayoutWithHole extends FrameLayout {
         Log.d("tourguide","getHeight: "+ size.y);
         Log.d("tourguide","getWidth: " + size.x);
 
+    }
+
+    private static Point getRealScreenSize(Context context) {
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+        Point size = new Point();
+
+        if (Build.VERSION.SDK_INT >= 17) {
+            display.getRealSize(size);
+        } else if (Build.VERSION.SDK_INT >= 14) {
+            try {
+                size.x = (Integer) Display.class.getMethod("getRawWidth").invoke(display);
+                size.y = (Integer) Display.class.getMethod("getRawHeight").invoke(display);
+            } catch (IllegalAccessException e) {} catch (InvocationTargetException e) {} catch (NoSuchMethodException e) {}
+        }
+
+        return size;
     }
 
     private boolean mCleanUpLock = false;


### PR DESCRIPTION
When using the tourguide on a fullscreen ui, with the navigation and status bars hidden, the framelayoutwithhole view does not cover the area behind the navigation bar. DisplayMetrics is used to get the screen size but it does not return the actual raw pixel dimensions of the screen. Use a different method to get the screen size.
