### PR TITLE
Handle CENTER_VERTICAL tooltip gravity.

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
@@ -396,11 +396,17 @@ public class TourGuide {
             } else {
                 y =  targetViewY - toolTipMeasuredHeight - (int)adjustment;
             }
-        } else { // this is center
+        } else if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
             if (((gravity & Gravity.LEFT) == Gravity.LEFT) || ((gravity & Gravity.RIGHT) == Gravity.RIGHT)) {
                 y =  targetViewY + mHighlightedView.getHeight() - (int) adjustment;
             } else {
                 y =  targetViewY + mHighlightedView.getHeight() + (int) adjustment;
+            }
+        } else { // this is center
+            if (((gravity & Gravity.LEFT) == Gravity.LEFT) || ((gravity & Gravity.RIGHT) == Gravity.RIGHT)) {
+                y =  targetViewY + mHighlightedView.getHeight() / 2 - (int) adjustment;
+            } else {
+                y =  targetViewY + mHighlightedView.getHeight() / 2 + (int) adjustment;
             }
         }
         return y;


### PR DESCRIPTION
When using CENTER_VERTICAL tooltip gravity, place the tooltip vertically centered relative to the view it is referring to.

Fixes issue #59.
