### PR TITLE
fast clicks in a sequence bug fix

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -141,7 +141,7 @@ public class FrameLayoutWithHole extends FrameLayout {
     private boolean mCleanUpLock = false;
     protected void cleanUp(){
         if (getParent() != null) {
-            if (mOverlay!=null && mOverlay.mExitAnimation!=null) {
+            if (mOverlay!=null && mOverlay.mExitAnimation!=null && !mCleanUpLock) {
                 performOverlayExitAnimation();
             } else {
                 ((ViewGroup) this.getParent()).removeView(this);
@@ -158,7 +158,7 @@ public class FrameLayoutWithHole extends FrameLayout {
                 @Override public void onAnimationRepeat(Animation animation) {}
                 @Override
                 public void onAnimationEnd(Animation animation) {
-                    ((ViewGroup) _pointerToFrameLayout.getParent()).removeView(_pointerToFrameLayout);
+                    if((_pointerToFrameLayout.getParent())!=null) ((ViewGroup) _pointerToFrameLayout.getParent()).removeView(_pointerToFrameLayout);
                 }
             });
             this.startAnimation(mOverlay.mExitAnimation);


### PR DESCRIPTION
in a sequence (only tested ContinueMethod.OverlayListener) fast clicks didn't remove the overlay correctly. therefore the UI was not useable anymore. this fixes "very" fast click through several tourguide steps. This happend when one animation starts before the last one has finished. this fix removes the "old" overlay.

needs some more testing!

regards
simon
