### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -40,6 +40,38 @@ public class FrameLayoutWithHole extends FrameLayout {
     private Overlay mOverlay;
 
     private ArrayList<AnimatorSet> mAnimatorSetArrayList;
+    private boolean mCleanUpLock = false;
+
+    public FrameLayoutWithHole(Activity context, View view) {
+        this(context, view, TourGuide.MotionType.AllowAll);
+    }
+
+    public FrameLayoutWithHole(Activity context, View view, TourGuide.MotionType motionType) {
+        this(context, view, motionType, new Overlay());
+    }
+
+    public FrameLayoutWithHole(Activity context, View view, TourGuide.MotionType motionType, Overlay overlay) {
+        super(context);
+        mActivity = context;
+        mViewHole = view;
+        init(null, 0);
+        enforceMotionType();
+        mOverlay = overlay;
+
+        int [] pos = new int[2];
+        mViewHole.getLocationOnScreen(pos);
+        mPos = pos;
+
+        mDensity = context.getResources().getDisplayMetrics().density;
+        int padding = (int)(20 * mDensity);
+
+        if (mViewHole.getHeight() > mViewHole.getWidth()) {
+            mRadius = mViewHole.getHeight()/2 + padding;
+        } else {
+            mRadius = mViewHole.getWidth()/2 + padding;
+        }
+        mMotionType = motionType;
+    }
 
     public void setViewHole(View viewHole) {
         this.mViewHole = viewHole;
@@ -72,35 +104,6 @@ public class FrameLayoutWithHole extends FrameLayout {
         }
     }
 
-    public FrameLayoutWithHole(Activity context, View view) {
-        this(context, view, TourGuide.MotionType.AllowAll);
-    }
-    public FrameLayoutWithHole(Activity context, View view, TourGuide.MotionType motionType) {
-        this(context, view, motionType, new Overlay());
-    }
-
-    public FrameLayoutWithHole(Activity context, View view, TourGuide.MotionType motionType, Overlay overlay) {
-        super(context);
-        mActivity = context;
-        mViewHole = view;
-        init(null, 0);
-        enforceMotionType();
-        mOverlay = overlay;
-
-        int [] pos = new int[2];
-        mViewHole.getLocationOnScreen(pos);
-        mPos = pos;
-
-        mDensity = context.getResources().getDisplayMetrics().density;
-        int padding = (int)(20 * mDensity);
-
-        if (mViewHole.getHeight() > mViewHole.getWidth()) {
-            mRadius = mViewHole.getHeight()/2 + padding;
-        } else {
-            mRadius = mViewHole.getWidth()/2 + padding;
-        }
-        mMotionType = motionType;
-    }
     private void init(AttributeSet attrs, int defStyle) {
         // Load attributes
 //        final TypedArray a = getContext().obtainStyledAttributes(
@@ -137,7 +140,6 @@ public class FrameLayoutWithHole extends FrameLayout {
 
     }
 
-    private boolean mCleanUpLock = false;
     protected void cleanUp(){
         if (getParent() != null) {
             if (mOverlay!=null && mOverlay.mExitAnimation!=null) {

--- a/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
@@ -55,14 +55,14 @@ public class TourGuide {
      *
      *************/
 
-    /* Static builder */
-    public static TourGuide init(Activity activity){
-        return new TourGuide(activity);
-    }
-
     /* Constructor */
     public TourGuide(Activity activity){
         mActivity = activity;
+    }
+
+    /* Static builder */
+    public static TourGuide init(Activity activity){
+        return new TourGuide(activity);
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213 The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Zeeshan Asghar
