### PR TITLE
Methods should not be empty

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -153,8 +153,12 @@ public class FrameLayoutWithHole extends FrameLayout {
             mCleanUpLock = true;
             Log.d("tourguide","Overlay exit animation listener is overwritten...");
             mOverlay.mExitAnimation.setAnimationListener(new Animation.AnimationListener() {
-                @Override public void onAnimationStart(Animation animation) {}
-                @Override public void onAnimationRepeat(Animation animation) {}
+                @Override public void onAnimationStart(Animation animation) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationRepeat(Animation animation) {
+                    throw new UnsupportedOperationException();
+                }
                 @Override
                 public void onAnimationEnd(Animation animation) {
                     ((ViewGroup) _pointerToFrameLayout.getParent()).removeView(_pointerToFrameLayout);

--- a/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
@@ -265,7 +265,9 @@ public class TourGuide {
             frameLayoutWithHole.setViewHole(mHighlightedView);
             frameLayoutWithHole.setSoundEffectsEnabled(false);
             frameLayoutWithHole.setOnClickListener(new View.OnClickListener() {
-                @Override public void onClick(View v) {} // do nothing, disabled.
+                @Override public void onClick(View v) {
+                    throw new UnsupportedOperationException();
+                } // do nothing, disabled.
             });
         }
     }
@@ -459,9 +461,15 @@ public class TourGuide {
             final AnimatorSet animatorSet = new AnimatorSet();
             final AnimatorSet animatorSet2 = new AnimatorSet();
             Animator.AnimatorListener lis1 = new Animator.AnimatorListener() {
-                @Override public void onAnimationStart(Animator animator) {}
-                @Override public void onAnimationCancel(Animator animator) {}
-                @Override public void onAnimationRepeat(Animator animator) {}
+                @Override public void onAnimationStart(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationCancel(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationRepeat(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
                 @Override
                 public void onAnimationEnd(Animator animator) {
                     view.setScaleX(1f);
@@ -471,9 +479,15 @@ public class TourGuide {
                 }
             };
             Animator.AnimatorListener lis2 = new Animator.AnimatorListener() {
-                @Override public void onAnimationStart(Animator animator) {}
-                @Override public void onAnimationCancel(Animator animator) {}
-                @Override public void onAnimationRepeat(Animator animator) {}
+                @Override public void onAnimationStart(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationCancel(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationRepeat(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
                 @Override
                 public void onAnimationEnd(Animator animator) {
                     view.setScaleX(1f);
@@ -536,9 +550,15 @@ public class TourGuide {
             final AnimatorSet animatorSet = new AnimatorSet();
             final AnimatorSet animatorSet2 = new AnimatorSet();
             Animator.AnimatorListener lis1 = new Animator.AnimatorListener() {
-                @Override public void onAnimationStart(Animator animator) {}
-                @Override public void onAnimationCancel(Animator animator) {}
-                @Override public void onAnimationRepeat(Animator animator) {}
+                @Override public void onAnimationStart(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationCancel(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationRepeat(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
                 @Override
                 public void onAnimationEnd(Animator animator) {
                     view.setScaleX(1f);
@@ -548,9 +568,15 @@ public class TourGuide {
                 }
             };
             Animator.AnimatorListener lis2 = new Animator.AnimatorListener() {
-                @Override public void onAnimationStart(Animator animator) {}
-                @Override public void onAnimationCancel(Animator animator) {}
-                @Override public void onAnimationRepeat(Animator animator) {}
+                @Override public void onAnimationStart(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationCancel(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
+                @Override public void onAnimationRepeat(Animator animator) {
+                    throw new UnsupportedOperationException();
+                }
                 @Override
                 public void onAnimationEnd(Animator animator) {
                     view.setScaleX(1f);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1186 Methods should not be empty

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1186

Please let me know if you have any questions.

Zeeshan Asghar
