### PR TITLE
General Code Improvement 3

### DIFF
--- a/app/src/androidTest/java/tourguide/tourguidedemo/SequenceTest.java
+++ b/app/src/androidTest/java/tourguide/tourguidedemo/SequenceTest.java
@@ -152,7 +152,7 @@ public class SequenceTest extends ActivityInstrumentationTestCase2<SequenceTestA
      * @param tourGuides
      * @param ActualSequence
      */
-    private void runOverlayListenerTest(TourGuide[] tourGuides, int ActualSequence){
+    private static void runOverlayListenerTest(TourGuide[] tourGuides, int ActualSequence){
 //        assertNotNull(mActivity.mTutorialHandler.mOverlay); //Overlay must not null
 //        assertNotNull(mActivity.mSequence.getOverlayListener());//Overlay must have OnClickListener
 //

--- a/app/src/androidTest/java/tourguide/tourguidedemo/ToolTilMeasureTest.java
+++ b/app/src/androidTest/java/tourguide/tourguidedemo/ToolTilMeasureTest.java
@@ -57,15 +57,13 @@ public class ToolTilMeasureTest extends ActivityInstrumentationTestCase2<ToolTip
         Display display = activity.getWindowManager().getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);
-        int width = size.x;
-        return width;
+        return size.x;
     }
     public int getScreenHeight(Activity activity) {
         Display display = activity.getWindowManager().getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);
-        int height = size.y;
-        return height;
+        return size.y;
     }
 
 }

--- a/app/src/main/java/tourguide/tourguidedemo/TourGuideDemoMain.java
+++ b/app/src/main/java/tourguide/tourguidedemo/TourGuideDemoMain.java
@@ -256,7 +256,7 @@ public class TourGuideDemoMain extends ActionBarActivity {
 //                text.setText("Memory Leak Test");
 //            }
 
-            return (row);
+            return row;
         }
 
     }

--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -244,10 +244,10 @@ public class FrameLayoutWithHole extends FrameLayout {
     private boolean isWithinButton(MotionEvent ev) {
         int[] pos = new int[2];
         mViewHole.getLocationOnScreen(pos);
-        return (ev.getRawY() >= pos[1] &&
+        return ev.getRawY() >= pos[1] &&
                 ev.getRawY() <= (pos[1] + mViewHole.getHeight()) &&
                 ev.getRawX() >= pos[0] &&
-                ev.getRawX() <= (pos[0] + mViewHole.getWidth()));
+                ev.getRawX() <= (pos[0] + mViewHole.getWidth());
     }
 
     @Override

--- a/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/TourGuide.java
@@ -249,7 +249,7 @@ public class TourGuide {
             }
         });
     }
-    private void checking(){
+    private static void checking(){
         // There is not check for tooltip because tooltip can be null, it means there no tooltip will be shown
 
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1488  Local Variables should not be declared and then immediately returned or thrown
squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar
