### PR TITLE
'public static' fields should be constant

### DIFF
--- a/app/src/androidTest/java/tourguide/tourguidedemo/SequenceTest.java
+++ b/app/src/androidTest/java/tourguide/tourguidedemo/SequenceTest.java
@@ -79,7 +79,7 @@ public class SequenceTest extends ActivityInstrumentationTestCase2<SequenceTestA
     public void testTourGuideSettings(){
 
         //overlay continue method
-        if (SequenceTestActivity.ChosenContinueMethod == SequenceTestActivity.OVERLAY_METHOD) {
+        if (SequenceTestActivity.CHOSEN_CONTINUE_METHOD == SequenceTestActivity.OVERLAY_METHOD) {
             Log.d(CLASS_NAME, "Method: Overlay");
             assertEquals(mActivity.mSequence.getContinueMethod(), Sequence.ContinueMethod.Overlay);
 
@@ -95,7 +95,7 @@ public class SequenceTest extends ActivityInstrumentationTestCase2<SequenceTestA
             button3.performClick();
         }
         //overlay listener continue method
-        else if (SequenceTestActivity.ChosenContinueMethod == SequenceTestActivity.OVERLAY_LISTENER_METHOD) {
+        else if (SequenceTestActivity.CHOSEN_CONTINUE_METHOD == SequenceTestActivity.OVERLAY_LISTENER_METHOD) {
             Log.d(CLASS_NAME, "Method: Overlay Listener");
             assertEquals(mActivity.mSequence.getContinueMethod(), Sequence.ContinueMethod.OverlayListener);
 

--- a/app/src/main/java/tourguide/instrumentation/test/SequenceTestActivity.java
+++ b/app/src/main/java/tourguide/instrumentation/test/SequenceTestActivity.java
@@ -40,10 +40,10 @@ public class SequenceTestActivity extends ActionBarActivity {
     private Button button, button2, button3;
     private Animation enterAnimation, exitAnimation;
 
-    public static int OVERLAY_METHOD = 1;
-    public static int OVERLAY_LISTENER_METHOD = 2;
+    public static final int OVERLAY_METHOD = 1;
+    public static final int OVERLAY_LISTENER_METHOD = 2;
 
-    public static int ChosenContinueMethod = 2; //by default, choose overlay method
+    public static final int CHOSEN_CONTINUE_METHOD = 2; //by default, choose overlay method
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -65,9 +65,9 @@ public class SequenceTestActivity extends ActionBarActivity {
         exitAnimation.setDuration(600);
         exitAnimation.setFillAfter(true);
 
-        if (ChosenContinueMethod == OVERLAY_METHOD) {
+        if (CHOSEN_CONTINUE_METHOD == OVERLAY_METHOD) {
             runOverlayContinueMethod();
-        } else if (ChosenContinueMethod == OVERLAY_LISTENER_METHOD){
+        } else if (CHOSEN_CONTINUE_METHOD == OVERLAY_LISTENER_METHOD){
             runOverlayListenerContinueMethod();
         }
 

--- a/app/src/main/java/tourguide/tourguidedemo/OverlaySequenceTourActivity.java
+++ b/app/src/main/java/tourguide/tourguidedemo/OverlaySequenceTourActivity.java
@@ -39,10 +39,10 @@ public class OverlaySequenceTourActivity extends ActionBarActivity {
     private Button mButton1, mButton2, mButton3;
     private Animation mEnterAnimation, mExitAnimation;
 
-    public static int OVERLAY_METHOD = 1;
-    public static int OVERLAY_LISTENER_METHOD = 2;
+    public static final int OVERLAY_METHOD = 1;
+    public static final int OVERLAY_LISTENER_METHOD = 2;
 
-    public static String CONTINUE_METHOD = "continue_method";
+    public static final String CONTINUE_METHOD = "continue_method";
     private int mChosenContinueMethod;
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1444 'public static' fields should be constant

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Zeeshan Asghar
