### PR TITLE
#88 fix: Overlay now factors in action bar, in case the app is fullscreen

### DIFF
--- a/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
+++ b/tourguide/src/main/java/tourguide/tourguide/FrameLayoutWithHole.java
@@ -134,7 +134,15 @@ public class FrameLayoutWithHole extends FrameLayout {
         size.x = mActivity.getResources().getDisplayMetrics().widthPixels;
         size.y = mActivity.getResources().getDisplayMetrics().heightPixels;
 
-        mEraserBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
+        final TypedArray styledAttributes = getContext().getTheme().obtainStyledAttributes(new int[] { android.R.attr.actionBarSize });
+        int actionBarSize = (int) styledAttributes.getDimension(0, 0);
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            size.x += actionBarSize;
+        } else {
+            size.y += actionBarSize;
+        }
+        
+        mEraserBitmap = Bitmap.createBitmap(size.x + actionBarSize, size.y + actionBarSize, Bitmap.Config.ARGB_8888);
         mEraserCanvas = new Canvas(mEraserBitmap);
 
         mPaint = new Paint();


### PR DESCRIPTION
Fixes #88, originally raised by me.

Checks where the action bar is, and increases the overlay bitmap by that size, in case the app is in fullscreen.