### PR TITLE
Make CI more stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   # Create and start emulator
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
-  - adb wait-for-device
+  - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script: ./gradlew build connectedCheck


### PR DESCRIPTION
Use updated version of wait, this include the wait for boot animation

ref: https://stackoverflow.com/a/46718068/75579
ref: https://docs.travis-ci.com/user/languages/android/#How-to-Create-and-Start-an-Emulator