### PR TITLE
Add hasNext() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Overlay overlay = new Overlay()
             .setStyle(Overlay.Style.Rectangle);
 ```
 - `disableClick(true)` will make elements covered by the overlay to become unclickable. Refer to Overlay Customization Activity in the example.
+- `disableClickThroughHole(true)` will make elements through the hole become unclickable.
 - `.setStyle()` Currently only 2 styles are available: `Overlay.Style.Rectangle` and `Overlay.Style.Circle`
 
 # Running TourGuide in Sequence

--- a/tourguide/src/main/java/tourguide/tourguide/ChainTourGuide.java
+++ b/tourguide/src/main/java/tourguide/tourguide/ChainTourGuide.java
@@ -60,7 +60,7 @@ public class ChainTourGuide extends TourGuide {
             cleanUp();
         }
 
-        if (mSequence.mCurrentSequence < mSequence.mTourGuideArray.length) {
+        if (hasNext()) {
             setToolTip(mSequence.getToolTip());
             setPointer(mSequence.getPointer());
             setOverlay(mSequence.getOverlay());
@@ -71,6 +71,10 @@ public class ChainTourGuide extends TourGuide {
             mSequence.mCurrentSequence++;
         }
         return this;
+    }
+
+    public boolean hasNext() {
+        return mSequence.mCurrentSequence < mSequence.mTourGuideArray.length;
     }
 
     /**************************


### PR DESCRIPTION
- Added ```hasNext()``` function to ChainTourGuide.
- Added info to Readme about ```disableClickThroughHole(...)```.

The logic for ```hasNext()``` already exists in the ```next()```, but by making it publicly accessable users of the ChainTourGuide can use ```hasNext()``` to determine if the end of the chain has been reached. This will allow performing some kind of action at the end of a chain of actions, like ```tour completed, don't run again``` settings.